### PR TITLE
Fix index.html for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="WorkFlowAI" />
     <meta name="msapplication-TileColor" content="#667eea" />
-    <meta name="msapplication-config" content="/browserconfig.xml" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
@@ -30,10 +29,10 @@
     <link rel="manifest" href="/manifest.json" />
 
     <!-- Apple Touch Icons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/icon-180x180.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/icon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/icon-16x16.png" />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#667eea" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/placeholder.svg" />
+    <link rel="icon" type="image/svg+xml" sizes="32x32" href="/placeholder.svg" />
+    <link rel="icon" type="image/svg+xml" sizes="16x16" href="/placeholder.svg" />
+    <link rel="mask-icon" href="/placeholder.svg" color="#667eea" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Update `index.html` to reference existing placeholder icons and remove a missing browser config to restore website accessibility.

The website was inaccessible due to `index.html` referencing several icon files (`icon-180x180.png`, `icon-32x32.png`, `icon-16x16.png`, `safari-pinned-tab.svg`, `browserconfig.xml`) that did not exist in the `/public` directory, leading to 404 errors and preventing the page from loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-a458a1f0-61da-43e7-910c-3c55d50f678d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a458a1f0-61da-43e7-910c-3c55d50f678d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

