### PR TITLE
CI linting failure

### DIFF
--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -174,6 +174,7 @@ export default [
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'warn', // Allow 'as any' in tests for mocking
+      'no-undef': 'off', // TypeScript handles this - prevents false positives with types
     },
   },
   {

--- a/apps/frontend/src/components/__tests__/ScrollToTop.test.tsx
+++ b/apps/frontend/src/components/__tests__/ScrollToTop.test.tsx
@@ -7,7 +7,7 @@ import ScrollToTop from '../ScrollToTop'
 describe('ScrollToTop component', () => {
   it('scrolls to top when no hash is present', () => {
     Object.defineProperty(window, 'requestAnimationFrame', {
-      value: (cb: FrameRequestCallback) => {
+      value: (cb: (time: number) => void) => {
         cb(0)
         return 0
       },

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "buildCommand": "npm install && npm run -w tcdynamics-frontend build",
+  "buildCommand": "npm install && npm run build:frontend",
   "outputDirectory": "apps/frontend/dist",
   "headers": [
     {


### PR DESCRIPTION
Fixes linting failure in GitHub Actions by disabling `no-undef` for test files and simplifying a type annotation.

The `no-undef` ESLint rule was incorrectly flagging `FrameRequestCallback` as undefined in test files because it's a type, not a runtime value. TypeScript's type checker already handles these checks, making the ESLint rule redundant and problematic in this context. Disabling it for tests prevents false positives.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ddbcf3a-6449-47ec-b933-9bfeabe10f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ddbcf3a-6449-47ec-b933-9bfeabe10f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI linting by disabling ESLint no-undef for test files and inlining the requestAnimationFrame callback type in ScrollToTop.test.tsx. Update Vercel build command to use npm run build:frontend so the frontend builds in GitHub Actions.

<sup>Written for commit 1b8666689f1f564100b186796e621885d23a7ce0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

