### PR TITLE
GitHub actions failures

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -19,9 +19,9 @@
     "test:e2e:debug": "playwright test --debug",
     "lighthouse": "lhci autorun",
     "preview": "vite preview",
-    "lint": "npx eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 150",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 150",
     "type-check": "tsc --noEmit",
-    "lint:fix": "npx eslint . --ext ts,tsx --fix",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write . --config tools/configs/.prettierrc --ignore-path tools/configs/.prettierignore",
     "format:check": "prettier --check . --config tools/configs/.prettierrc --ignore-path tools/configs/.prettierignore",
     "prepare": "husky",
@@ -33,11 +33,11 @@
     "verify-bugbots": "node scripts/verify-bugbots.js",
     "pre-push-checks": "node scripts/pre-push-checks.js",
     "verify": "npm run lint && npm run type-check && npm run test -- --run",
-    "verify:exercise": "npx eslint src/utils/math.ts src/utils/__tests__/math.test.ts --ext ts,tsx && tsc --noEmit --pretty false --skipLibCheck && vitest --run src/utils/__tests__/math.test.ts"
+    "verify:exercise": "eslint src/utils/math.ts src/utils/__tests__/math.test.ts && tsc --noEmit --pretty false --skipLibCheck && vitest --run src/utils/__tests__/math.test.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "npx eslint --fix",
+      "eslint --fix",
       "prettier --write --config ../../tools/configs/.prettierrc --ignore-path ../../tools/configs/.prettierignore"
     ],
     "*.{json,md,css}": [

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "lint": "echo 'No linting configured for shared-types'",
+    "type-check": "tsc --noEmit"
   },
   "exports": {
     "./api": {

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "lint": "echo 'No linting configured for shared-utils'",
+    "type-check": "tsc --noEmit"
   },
   "exports": {
     "./sanitize": {


### PR DESCRIPTION
Fixes GitHub Actions failures by adding missing `lint`/`type-check` scripts to shared packages and correcting frontend ESLint invocation.

The "Bump dev dependencies" workflow failed because `packages/shared-types` and `packages/shared-utils` lacked `lint` and `type-check` scripts, which are required when running `npm run -ws`. The "Quality Gate" workflow failed due to `apps/frontend` using `npx eslint`, which incorrectly downloaded ESLint 10 instead of using the locally installed version 9, leading to module resolution errors.

---
<p><a href="https://cursor.com/agents?id=bc-fc361fa7-e157-407b-9245-5adccb97e5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc361fa7-e157-407b-9245-5adccb97e5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/lawmight/TCDynamics/169?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub Actions CI failures by adding missing scripts in shared packages and using the local ESLint in the frontend. This unblocks the "Bump dev dependencies" and "Quality Gate" workflows.

- **Bug Fixes**
  - Added lint and type-check scripts to shared-types and shared-utils so workspace lint/type-check runs succeed.
  - Switched frontend scripts and lint-staged to use local eslint instead of npx; stops accidental ESLint 10 installs and resolves module errors.
  - Removed obsolete --ext flag; flat config handles file matching.

<sup>Written for commit 1ee0562041d4bcc69597e854cb1f7c5912add41f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

