### PR TITLE
Github action failure

### DIFF
--- a/.github/workflows/bump-dev-deps.yml
+++ b/.github/workflows/bump-dev-deps.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Verify (install + lint + type-check + tests)
         run: |
           npm ci
-          npm run lint -ws
-          npm run type-check -ws
+          npm run lint -ws --if-present
+          npm run type-check -ws --if-present
           npm run test -ws --if-present
 
       - name: Commit and push (only if verify passed)

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -87,10 +87,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          # Install only frontend so apps/frontend/node_modules has @eslint/js (ESM resolution)
-          skip-root: true
-          skip-api: false
 
       - name: Type Check
         id: type-check

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -19,9 +19,9 @@
     "test:e2e:debug": "playwright test --debug",
     "lighthouse": "lhci autorun",
     "preview": "vite preview",
-    "lint": "npx eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 150",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 150",
     "type-check": "tsc --noEmit",
-    "lint:fix": "npx eslint . --ext ts,tsx --fix",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write . --config tools/configs/.prettierrc --ignore-path tools/configs/.prettierignore",
     "format:check": "prettier --check . --config tools/configs/.prettierrc --ignore-path tools/configs/.prettierignore",
     "prepare": "husky",
@@ -33,11 +33,11 @@
     "verify-bugbots": "node scripts/verify-bugbots.js",
     "pre-push-checks": "node scripts/pre-push-checks.js",
     "verify": "npm run lint && npm run type-check && npm run test -- --run",
-    "verify:exercise": "npx eslint src/utils/math.ts src/utils/__tests__/math.test.ts --ext ts,tsx && tsc --noEmit --pretty false --skipLibCheck && vitest --run src/utils/__tests__/math.test.ts"
+    "verify:exercise": "eslint src/utils/math.ts src/utils/__tests__/math.test.ts && tsc --noEmit --pretty false --skipLibCheck && vitest --run src/utils/__tests__/math.test.ts"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "npx eslint --fix",
+      "eslint --fix",
       "prettier --write --config ../../tools/configs/.prettierrc --ignore-path ../../tools/configs/.prettierignore"
     ],
     "*.{json,md,css}": [

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "lint": "echo 'No lint configured'",
+    "type-check": "tsc --noEmit"
   },
   "exports": {
     "./api": {

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "lint": "echo 'No lint configured'",
+    "type-check": "tsc --noEmit"
   },
   "exports": {
     "./sanitize": {


### PR DESCRIPTION
Fixes multiple CI failures related to ESLint setup and missing `lint`/`type-check` scripts in shared packages.

The CI was failing due to three main issues:
1. The `quality-gate` workflow's `skip-root: true` prevented proper binary linking, leading to `eslint: not found`.
2. `npx eslint` in `apps/frontend` was downloading ESLint 10, which is incompatible with the project's ESLint 9 flat config.
3. `npm run lint -ws` and `npm run type-check -ws` in `bump-dev-deps` failed because `@tcd/shared-types` and `@tcd/shared-utils` lacked these scripts.

---
<p><a href="https://cursor.com/agents?id=bc-efbc39c4-5b48-438e-8fce-299041966573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efbc39c4-5b48-438e-8fce-299041966573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/lawmight/TCDynamics/170?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures in Quality Gate and bump-dev-deps by aligning ESLint usage with our flat config and ensuring workspace scripts exist. This stabilizes linting and type-checking across the monorepo.

- **Bug Fixes**
  - Quality Gate: removed skip-root so root npm ci runs and eslint is linked in the workspace.
  - Frontend: replaced "npx eslint" with "eslint" and dropped "--ext" to match ESLint 9 flat config; updated lint-staged and verify:exercise accordingly.
  - Shared packages: added "lint" and "type-check" scripts to shared-types and shared-utils so workspace runs succeed.
  - bump-dev-deps: added "--if-present" to workspace lint/type-check steps for resilience.

<sup>Written for commit 5cbffd27c9d08dd06b9e756936d6b98f6fd187ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

