### PR TITLE
fix(frontend): hide section navigation dots when footer is visible

### DIFF
--- a/apps/frontend/src/components/Footer.tsx
+++ b/apps/frontend/src/components/Footer.tsx
@@ -9,7 +9,10 @@ import Users from '~icons/lucide/users'
 
 const Footer = () => {
   return (
-    <footer className="border-t border-border/40 bg-background py-12">
+    <footer
+      id="site-footer"
+      className="border-t border-border/40 bg-background py-12"
+    >
       <h2 className="sr-only">Pied de page du site</h2>
       <div className="container mx-auto px-4">
         {/* Top Row: Trust Signals */}

--- a/apps/frontend/src/components/SectionIndicators.tsx
+++ b/apps/frontend/src/components/SectionIndicators.tsx
@@ -1,3 +1,7 @@
+import { useEffect, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
 /** Default label mapping for section IDs */
 const DEFAULT_LABELS: Record<string, string> = {
   hero: 'Présentation',
@@ -23,11 +27,38 @@ interface SectionIndicatorsProps {
  * - Click scrolls to section via scrollIntoView
  * - Full accessibility: aria-label, aria-current, keyboard navigation
  */
+/**
+ * Hide fixed dots when the site footer scrolls into view so they never cover
+ * footer content (e.g. Mentions column on the home page).
+ */
+function useHideIndicatorsForFooter(): boolean {
+  const [hide, setHide] = useState(false)
+
+  useEffect(() => {
+    const footer = document.getElementById('site-footer')
+    if (!footer) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setHide(entry.isIntersecting)
+      },
+      { root: null, rootMargin: '0px', threshold: 0 },
+    )
+
+    observer.observe(footer)
+    return () => observer.disconnect()
+  }, [])
+
+  return hide
+}
+
 const SectionIndicators = ({
   activeId,
   sectionIds,
   labels = DEFAULT_LABELS,
 }: SectionIndicatorsProps) => {
+  const hideNearFooter = useHideIndicatorsForFooter()
+
   const indicators = sectionIds.map(id => ({
     id,
     label: labels[id] || id,
@@ -45,7 +76,10 @@ const SectionIndicators = ({
       {/* Desktop indicators - right side */}
       <nav
         aria-label="Navigation des sections"
-        className="section-indicators section-indicators--desktop"
+        className={cn(
+          'section-indicators section-indicators--desktop',
+          hideNearFooter && 'section-indicators--hidden',
+        )}
       >
         <ul>
           {indicators.map(({ id, label }) => (
@@ -96,7 +130,10 @@ const SectionIndicators = ({
       {/* Mobile indicators - bottom center */}
       <nav
         aria-label="Navigation des sections"
-        className="section-indicators section-indicators--mobile"
+        className={cn(
+          'section-indicators section-indicators--mobile',
+          hideNearFooter && 'section-indicators--hidden',
+        )}
       >
         <ul>
           {indicators.map(({ id, label }) => (

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -677,6 +677,11 @@ main#main .overflow-y-auto.has-overflow::-webkit-scrollbar-thumb {
   pointer-events: none;
 }
 
+/* Hide when footer is in view (home page) — overrides lg display below */
+.section-indicators.section-indicators--hidden {
+  display: none !important;
+}
+
 .section-indicators--desktop {
   position: fixed;
   right: 1.25rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The fixed section-indicator dots (desktop right rail / mobile bottom bar) overlapped the footer **Mentions** column and legal links.

## Changes
- Add `id="site-footer"` on the global `Footer` for observation.
- In `SectionIndicators`, use an `IntersectionObserver` on `#site-footer`: when any part of the footer enters the viewport, apply `section-indicators--hidden` which sets `display: none !important` on both desktop and mobile indicator navs so they are fully removed (no overlap, no stray focus targets).
- When the user scrolls back up so the footer leaves the viewport, the dots reappear.

## Testing
- Manual: scroll home page to bottom — dots should disappear before/during footer overlap; scroll up — dots return.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83f3b071-60f1-4bfd-a9fc-b7f66ed44319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83f3b071-60f1-4bfd-a9fc-b7f66ed44319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide section navigation dots when the footer is in view to prevent overlap with the Mentions and legal links. Dots reappear when the footer leaves the viewport.

- **Bug Fixes**
  - Added `id="site-footer"` to the global `Footer`.
  - In `SectionIndicators`, used an `IntersectionObserver` on `#site-footer` to toggle a `section-indicators--hidden` class for both desktop and mobile dots.
  - Added CSS to fully hide the indicators (`display: none !important`) so they don’t overlap or remain focusable.

<sup>Written for commit 8f3c3ae24b3bfe08507c365e3eb3a3eb230afd0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

