### PR TITLE
fix(backend): switch Jest coverageProvider to v8 to fix test failures

### DIFF
--- a/apps/backend/jest.config.cjs
+++ b/apps/backend/jest.config.cjs
@@ -61,4 +61,5 @@ module.exports = {
     },
   },
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.js'],
+  coverageProvider: 'v8',
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes 5 failing backend test suites (7 failing tests out of 28 run) caused by a `babel-plugin-istanbul` / `glob` version incompatibility.

### Root Cause

`babel-plugin-istanbul@7` bundles `test-exclude@6`, which calls `util.promisify(require('glob'))`. However, the root `node_modules/glob` is v10, which exports a plain object (ESM-style) rather than a function. Node's `util.promisify` requires a function, so it throws:

```
TypeError: The "original" argument must be of type function. Received an instance of Object
```

This error was triggered the moment any covered source file was `require()`-d inside a test, causing the entire test suite to fail to run.

### Fix

Added `coverageProvider: 'v8'` to `apps/backend/jest.config.cjs`. This switches Jest's code coverage from Babel-based instrumentation (`babel-plugin-istanbul`) to Node's built-in V8 coverage, which completely bypasses the problematic Babel transform. No source files were modified.

### Test Results

- ✅ `npm run test:backend` — **108 tests, 8 suites, all pass** (was 7 failures / 5 suites failing to run)
- ✅ `npm run test:frontend -- --run` — **422 tests, 63 suites, all pass** (unchanged)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04fc830c-55d5-4ee4-b125-b1e0a81118a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04fc830c-55d5-4ee4-b125-b1e0a81118a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Jest coverage to V8 in the backend to bypass a `babel-plugin-istanbul` and `glob@10` incompatibility that was crashing tests. All backend test suites now pass; no source files changed.

- **Bug Fixes**
  - Set `coverageProvider: 'v8'` in `apps/backend/jest.config.cjs`.
  - Avoids `util.promisify(require('glob'))` error from `test-exclude@6` via `babel-plugin-istanbul@7`.
  - Result: 108 backend tests across 8 suites pass; frontend unchanged.

<sup>Written for commit cd0f2e7b55682230b221ec05ba5b147f09cc199a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

