### PR TITLE
Fix backend Jest coverage execution

### DIFF
--- a/apps/backend/jest.config.cjs
+++ b/apps/backend/jest.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   testEnvironment: 'node',
+  coverageProvider: 'v8',
   // Restrict Jest to only search within this backend directory
   roots: ['<rootDir>/src'],
   // Only match test files within this backend directory


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch backend Jest coverage to the V8 provider in `apps/backend/jest.config.cjs`
- avoid the Babel Istanbul instrumentation path that was crashing the backend test script
- preserve the existing backend coverage reports and thresholds while restoring the default `npm run test:backend` flow

## Testing
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test:backend`
- `source ~/.nvm/nvm.sh && nvm use 20 && npx jest --coverage=false --verbose`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test:frontend -- --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-178d6d63-8243-4187-bb98-8281e39acdfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-178d6d63-8243-4187-bb98-8281e39acdfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch backend `jest` coverage to the V8 provider to restore coverage execution and avoid Babel/Istanbul instrumentation crashes. Coverage thresholds and report outputs remain unchanged.

<sup>Written for commit e91aed3f9cc19e7bd6d3394275695299bc4ae4c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

